### PR TITLE
fix: WiFi/Bluetooth testing causes testService to hang

### DIFF
--- a/mtkSetup.adef
+++ b/mtkSetup.adef
@@ -1,6 +1,6 @@
 sandboxed: false
 start: manual
-version: 3.0.1
+version: 3.0.2
 
 executables:
 {

--- a/upload/upload.c
+++ b/upload/upload.c
@@ -37,7 +37,7 @@ void configureSerialPort(FlashState* s, int baud) {
   if (s->serialPort != -1) {
     close(s->serialPort);
   }
-  s->serialPort = fd_openSerial(SERIAL_PORT_PATH, MTK7697_BAUD);
+  s->serialPort = fd_openSerial(SERIAL_PORT_PATH, baud);
 } 
 
 bool flashDa(FlashState* s) {
@@ -104,7 +104,7 @@ bool mtk_verifyInitSequence(FlashState* s) {
       LE_INFO("Init done");
       break;
     }
-    if((util_getUnixDatetime() - s->startTime > 3) && data == 0){
+    if((util_getUnixDatetime() - s->startTime > 3) && data != 'C'){
       LE_INFO("Retrying serial");
       retryInitSequence(s);
       }


### PR DESCRIPTION
The method of controlling serial ports caused the testService
to hang when data was not available on read.

HW-25